### PR TITLE
Refine function type signatures to be stricter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,10 +204,7 @@ export function spawnDetached(exe: string, params: Array<string>, opts: SpawnOpt
 export function spawn(exe: string, params: Array<string>, opts?: SpawnOptionsNoSplit): Observable<string>;
 export function spawn(exe: string, params: Array<string>, opts?: SpawnOptionsSplit): Observable<SplitOutput>;
 export function spawn(exe: string, params: Array<string> = [], opts: SpawnOptions = {}): Observable<SplitOutput|string> {
-  let spawnObs = Observable.create((subj: Observer<{
-    source: any,
-    text: any
-    }>) => {
+  let spawnObs = Observable.create((subj: Observer<SplitOutput>) => {
     let { cmd, args } = findActualExecutable(exe, params);
     d(`spawning process: ${cmd} ${args.join()}, ${JSON.stringify(opts)}`);
     let origOpts = assign({}, opts);
@@ -220,7 +217,7 @@ export function spawn(exe: string, params: Array<string> = [], opts: SpawnOption
 
     const proc = spawnOg(cmd, args, origOpts);
 
-    let bufHandler = (source: string) => (b: string | Buffer) => {
+    let bufHandler = (source: 'stdout' | 'stderr') => (b: string | Buffer) => {
       if (b.length < 1) {
         return;
       };

--- a/test/spawn.ts
+++ b/test/spawn.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import './support';
 
-import { spawn, spawnPromise, spawnDetachedPromise } from '../src/index';
+import { spawn, spawnPromise, spawnDetachedPromise, SplitOutput } from '../src/index';
 
 import { Observable } from 'rxjs';
 
@@ -58,7 +58,7 @@ describe('The spawn method', function() {
 
   it('should return split stderr in a inner tag when called with split', async function() {
     // provide an invalid param to uuid so it complains on stderr
-    let rxSpawn: Observable<{ source: any, text: any }> = spawn('uuid', ['foo'], {split: true}) as any;
+    let rxSpawn: Observable<SplitOutput> = spawn('uuid', ['foo'], {split: true});
     let result = await wrapSplitObservableInPromise(rxSpawn);
     expect(result.stderr.length > 10).to.be.ok;
     expect(result.stdout).to.be.empty;
@@ -66,7 +66,7 @@ describe('The spawn method', function() {
   });
 
   it('should return split stdout in a inner tag when called with split', async function() {
-    let rxSpawn: Observable<{ source: any, text: any }> = spawn('uuid', [], {split: true});
+    let rxSpawn: Observable<SplitOutput> = spawn('uuid', [], {split: true});
     let result = await wrapSplitObservableInPromise(rxSpawn);
     expect(result.stdout.match(uuidRegex)).to.be.ok;
     expect(result.stderr).to.be.empty;
@@ -74,27 +74,27 @@ describe('The spawn method', function() {
   });
 
   it('should ignore stderr if options.stdio = ignore', async function() {
-    let rxSpawn: Observable<{ source: any, text: any }> = spawn('uuid', ['foo'], {split: true, stdio: [null, null, 'ignore']});
+    let rxSpawn: Observable<SplitOutput> = spawn('uuid', ['foo'], {split: true, stdio: [null, null, 'ignore']});
     let result = await wrapSplitObservableInPromise(rxSpawn);
     expect(result.stderr).to.be.empty;
   });
 
   it('should ignore stdout if options.stdio = inherit', async function() {
-    let rxSpawn: Observable<{ source: any, text: any }> = spawn('uuid', [], {split: true, stdio: [null, 'inherit', null]});
+    let rxSpawn: Observable<SplitOutput> = spawn('uuid', [], {split: true, stdio: [null, 'inherit', null]});
     let result = await wrapSplitObservableInPromise(rxSpawn);
     expect(result.stdout).to.be.empty;
   });
 
   it('should croak if stdin is provided but stdio.stdin is disabled', async function() {
     let stdin = Observable.of('a');
-    let rxSpawn: Observable<{ source: any, text: any }>  = spawn('marked', [], {split: true, stdin: stdin, stdio: ['ignore', null, null]});
+    let rxSpawn: Observable<SplitOutput> = spawn('marked', [], {split: true, stdin: stdin, stdio: ['ignore', null, null]});
     let result = await wrapSplitObservableInPromise(rxSpawn);
     expect(result.error).to.be.an('error');
   });
 
   it('should subscribe to provided stdin', async function() {
     let stdin = Observable.of('a');
-    let rxSpawn: Observable<{ source: any, text: any }> = spawn('marked', [], {split: true, stdin: stdin});
+    let rxSpawn: Observable<SplitOutput> = spawn('marked', [], {split: true, stdin: stdin});
     let result = await wrapSplitObservableInPromise(rxSpawn);
     expect(result.stdout.trim()).to.be.equal('<p>a</p>');
   });


### PR DESCRIPTION
Hi,

I took the liberty to further annotate the spawn* function type signatures, so that the consumer either gets an `Observable` of `string`s or `SplitOutput`s, but never a combination of both.

This allowed me to get rid of a bunch of `any` casts in the tests as well.

Hope this is useful to the community :)